### PR TITLE
Blind target position estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ you will se all you IKEA lightbulbs in your iPhone/iPad Home app.
 
 ## Bugfixes/Updates
 
-* 2019-08-19 -  Added support for blinds.
 * 2018-01-29 -  Can now have accessories with the same name in the IKEA app
 * 2018-02-04 -  Updated to work with gateway version 1.3.14.
                 The security code must now be present in **~/.homebrige/config.json**.
 * 2019-01-19 -  Added support for outlets.
+* 2019-08-19 -  Added support for blinds.
 
 ## Useful Links
 

--- a/src/blind.js
+++ b/src/blind.js
@@ -9,39 +9,41 @@ module.exports = class Blind extends Device {
         this.blind = new this.Service.WindowCovering(this.name, this.uuid);
 
         this.addService('blind', this.blind);
-
         this.enablePosition();
         this.enableTargetPosition();
+        this.previousPosition = this.position;
     }
 
     deviceChanged(device) {
         super.deviceChanged();
         this.updatePosition();
+        this.estimateTargetPositionIfNeeded();
+        this.previousPosition = this.position;
     }
 
     enablePosition() {
         var position = this.blind.getCharacteristic(this.Characteristic.CurrentPosition)
         position.on('get', (callback) => {
-            callback(null, this.position)
+            callback(null, this.position);
         });
-        this.updatePosition()
+        this.updatePosition();
     }
 
     enableTargetPosition() {
-        var targetPosition = this.blind.getCharacteristic(this.Characteristic.TargetPosition)
+        var targetPosition = this.blind.getCharacteristic(this.Characteristic.TargetPosition);
         targetPosition.on('get', (callback) => {
-            callback(null, this.targetPosition)
+            callback(null, this.targetPosition);
         });
         targetPosition.on('set', (value, callback) => {
             this.setTargetPosition(value, callback);
         });
-        this.updateTargetPosition()
+        this.updateTargetPosition(this.position);
     }
 
     setTargetPosition(value, callback) {
         this.log('Setting target position to %s on blind \'%s\'', value, this.name);
-        this.position = value
-        this.targetPosition = value
+        this.position = value;
+        this.targetPosition = value;
         this.platform.gateway.operateBlind(this.device, {
             position: 100 - value
         })
@@ -51,18 +53,36 @@ module.exports = class Blind extends Device {
         });
     }
 
+    estimateTargetPositionIfNeeded() {
+        let position = this.position;
+        let increasing = this.previousPosition < position && this.targetPosition < position;
+        let decreasing = this.previousPosition > position && this.targetPosition > position;
+        if (increasing) {
+            this.updateTargetPosition(100);
+        } else if (decreasing) {
+            this.updateTargetPosition(0);
+        }
+
+        setTimeout(() => {
+            // If no new position we can assume that blinds has been stopped
+            if (this.position === position) {
+                this.updateTargetPosition(this.position);
+            }
+        }, 2000);
+    }
+
     updatePosition() {
-        var blind = this.device.blindList[0]
-        var position = this.blind.getCharacteristic(this.Characteristic.CurrentPosition)
+        var blind = this.device.blindList[0];
+        var position = this.blind.getCharacteristic(this.Characteristic.CurrentPosition);
         this.position = 100 - blind.position;
         this.log('Updating position to %s on blind \'%s\'', this.position, this.name);
         position.updateValue(this.position);
     }
 
-    updateTargetPosition() {
-        var targetPosition = this.blind.getCharacteristic(this.Characteristic.TargetPosition)
-        this.targetPosition = this.position
-        this.log('Updating taget position to %s on blind \'%s\'', this.targetPosition, this.name);
+    updateTargetPosition(position) {
+        var targetPosition = this.blind.getCharacteristic(this.Characteristic.TargetPosition);
+        this.targetPosition = position;
+        this.log('Updating target position to %s on blind \'%s\'', this.targetPosition, this.name);
         targetPosition.updateValue(this.targetPosition);
     }
 };


### PR DESCRIPTION
When using the remote instead of the Home app to control the blinds the target position was not updated and thus the UI in the Home app would get out of sync. This adds support for updating the target position by

- Setting the target position to 100% if current position is increasing and current target position is lower than current position
- Setting the target position to 0% if current position is decreasing and current target position is higher than current position

Further if no device updates has been received for 2 seconds then we can assume that movement has stopped and the target position is set to the current position.

These changes makes the UI in the Home app stay in sync with the blinds even if controlled with the remote.

Fixes #18 