### PR TITLE
Added support for only exposing non-IKEA devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Configure your **~/.homebridge/config.json** with the following platform.
 }
 
 ```
+> You can also only expose non-IKEA devices (which are not exposed to HomeKit with the native integration) with:  
+> "expose: ["non-ikea-lightbulbs", "non-ikea-outlets", "non-ikea-blinds"]
 
 This module auto detects the ip address of the IKEA gateway. If by
 some reason you would like to access a specific gateway, merge the following into 

--- a/src/platform.js
+++ b/src/platform.js
@@ -63,6 +63,9 @@ module.exports = class Platform extends Gateway {
             expose['outlets'] = true;
             expose['lightbulbs'] = true;
             expose['blinds'] = true;
+            expose['non-ikea-outlets'] = false;
+            expose['non-ikea-lightbulbs'] = false;
+            expose['non-ikea-blinds'] = false;
         }
 
         for (var id in this.gateway.devices) {
@@ -72,8 +75,8 @@ module.exports = class Platform extends Gateway {
             switch (device.type) {
                 case Ikea.AccessoryTypes.plug: {
 
-                    // Make sure the device has a plugList                    
-                    if (device.plugList && expose['outlets'])
+                    // Make sure the device has a plugList and is to be exposed
+                    if (device.plugList && (expose['outlets'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-outlets'])))
                         supportedDevice = new Outlet(this, device);
                     
                     break;
@@ -81,8 +84,8 @@ module.exports = class Platform extends Gateway {
 
                 case Ikea.AccessoryTypes.lightbulb: {
 
-                    // Make sure the device has a lightList
-                    if (device.lightList && expose['lightbulbs']) {
+                    // Make sure the device has a lightList and is to be exposed
+                    if (device.lightList && (expose['lightbulbs'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-lightbulbs']))) {
                         var spectrum = device.lightList[0]._spectrum;
 
                         switch(spectrum) {
@@ -108,8 +111,8 @@ module.exports = class Platform extends Gateway {
 
                 case Ikea.AccessoryTypes.blind: {
 
-                    // Make sure the device has a blindList                    
-                    if (device.blindList && expose['blinds'])
+                    // Make sure the device has a blindList and is to be exposed
+                    if (device.blindList && (expose['blinds'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-blinds'])))
                         supportedDevice = new Blind(this, device);
                     
                     break;


### PR DESCRIPTION
This PR adds support for only exposing non-IKEA devices to HomeKit. 

You can add non-IKEA devices to the Trådfri gateway, but they do not show up in HomeKit with the native Trådfri HomeKit integration. 
This PR allows you to use the native HomeKit integration for IKEA devices, while using this plugin to add non-IKEA devices to HomeKit.

It is implemented in a way that does not break any current configurations, and does not create problems if adding both the new and old values to the `expose` array. 
I.e. `"expose": ["lightbulbs", "non-ikea-lightbulbs"]` gives the same result as `"expose": ["lightbulbs"]`

Only tested with lightbulbs, as I do not have any non-IKEA outlets or blinds connected to my Trådfri gateway. 

(Sorry about the last PR, I goofed). 

Any feedback is appreciated.