### PR TITLE
supply tradfriclient options through config.json

### DIFF
--- a/src/gateway.js
+++ b/src/gateway.js
@@ -71,7 +71,11 @@ module.exports = class Gateway  {
             })
 
             .then((host) => {
-                this.gateway = new Ikea.TradfriClient(host);
+                if (this.config.clientOptions != undefined) {
+                    this.gateway = new Ikea.TradfriClient(host, this.config.clientOptions);
+                } else {
+                    this.gateway = new Ikea.TradfriClient(host);
+                }
 
                 this.gateway.on('device updated', (device) => {
                     this.deviceUpdated(device);


### PR DESCRIPTION
I use multiple platforms in my homebridge config. For example I use "homebridge-fritz-platform" and was running into the "The gateway did not respond in time" error message.

The solution for me was to set the "maximumConnectionAttempts" for the used tradfri client lib a little higher than 1. With this patch it can be done in config.json like this:

```
{
  "platform": "Ikea Trådfri Gateway",
  "name": "Ikea Trådfri Gateway",
  "host": "GW-1234",
  "identity": "12345",
  "psk": "1234",
  "expose": [
        "blinds"
  ],
  "clientOptions": {
    "watchConnection": {
      "maximumConnectionAttempts": 8
    }
  }
}
```