### PR TITLE
Added support for remotes for low battery notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you are having permission problems during install, try this
 
 Configure your **~/.homebridge/config.json** with the following platform.
 
-```javascript
+```json
 {
     "bridge": {
         "name": "Trådfri",
@@ -52,7 +52,8 @@ Configure your **~/.homebridge/config.json** with the following platform.
             "platform": "Ikea Trådfri Gateway",
             "name": "Ikea Trådfri Gateway",
             "securityCode" : "this-is-found-on-the-back-of-the-gateway",
-            "expose": ["lightbulbs", "outlets", "blinds"]
+            "lowBatteryLimit": 50,
+            "expose": ["lightbulbs", "outlets", "blinds", "remotes", "shortcut-buttons"]
         }
     ]
 }
@@ -66,7 +67,7 @@ some reason you would like to access a specific gateway, merge the following int
 **~/.homebridge/config.json**.
 
 
-```javascript
+```json
 {
     ...
     "platforms": [

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following IKEA devices are supported
 - Warm white bulbs with temperature control
 - Outlets
 - Blinds
+- Remotes (including shortcut buttons)
 
 After this, start **homebridge**, scan the presented code with your iPhone, and hopefully
 you will se all you IKEA lightbulbs in your iPhone/iPad Home app.
@@ -117,6 +118,7 @@ you will se all you IKEA lightbulbs in your iPhone/iPad Home app.
                The **host** property in **~/.homebridge/config.json** is no longer required.
 * 2019-11-27 - Added support for non IKEA devices. 
 * 2021-05-30 - Updated dependencies in package.json
+* 2022-11-13 - Added support for remotes and shortcut buttons for low battery notifications.
 
 ## Useful Links
 

--- a/config.json
+++ b/config.json
@@ -14,7 +14,8 @@
             "platform": "Ikea Trådfri Gateway",
             "name": "Ikea Trådfri Gateway",
             "securityCode" : "security-code-from-the-back-of-gateway",
-            "expose": ["lightbulbs", "outlets", "blinds"],
+            "lowBatteryLimit": 50,
+            "expose": ["lightbulbs", "outlets", "blinds", "remotes", "shortcut-buttons"],
             "ignore": ["65537", "65540", "65550"]
         }
     ]

--- a/src/platform.js
+++ b/src/platform.js
@@ -6,6 +6,7 @@ var Lightbulb          = require('./lightbulb.js');
 var WarmWhiteLightbulb = require('./warm-white-lightbulb.js');
 var RgbLightbulb       = require('./rgb-lightbulb.js');
 var Outlet             = require('./outlet.js');
+var Remote             = require('./remote.js');
 var Blind             = require('./blind.js');
 var Gateway            = require('./gateway.js');
 var Ikea               = require('node-tradfri-client');
@@ -63,9 +64,12 @@ module.exports = class Platform extends Gateway {
             expose['outlets'] = true;
             expose['lightbulbs'] = true;
             expose['blinds'] = true;
+            expose['remotes'] = true;
+            expose['shortcut-buttons'] = true;
             expose['non-ikea-outlets'] = false;
             expose['non-ikea-lightbulbs'] = false;
             expose['non-ikea-blinds'] = false;
+            expose['non-ikea-remotes'] = false;
         }
 
         for (var id in this.gateway.devices) {
@@ -114,7 +118,18 @@ module.exports = class Platform extends Gateway {
                     // Make sure the device has a blindList and is to be exposed
                     if (device.blindList && (expose['blinds'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-blinds'])))
                         supportedDevice = new Blind(this, device);
-                    
+
+                    break;
+                }
+
+                case Ikea.AccessoryTypes.remote:
+                case Ikea.AccessoryTypes.slaveRemote: {
+                    console.log(device.type, device);
+                    // Make sure the device has a remoteList and is to be exposed
+                    const isShortcutButton = device.deviceInfo.modelNumber === 'TRADFRI SHORTCUT Button';
+                    if (device.switchList && ((isShortcutButton && expose['shortcut-buttons']) || (!isShortcutButton && expose['remotes'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-remotes']))))
+                        supportedDevice = new Remote(this, device);
+
                     break;
                 }
             }

--- a/src/platform.js
+++ b/src/platform.js
@@ -124,7 +124,7 @@ module.exports = class Platform extends Gateway {
 
                 case Ikea.AccessoryTypes.remote:
                 case Ikea.AccessoryTypes.slaveRemote: {
-                    console.log(device.type, device);
+                    
                     // Make sure the device has a remoteList and is to be exposed
                     const isShortcutButton = device.deviceInfo.modelNumber === 'TRADFRI SHORTCUT Button';
                     if (device.switchList && ((isShortcutButton && expose['shortcut-buttons']) || (!isShortcutButton && expose['remotes'] || (device.deviceInfo.manufacturer !== 'IKEA of Sweden' && expose['non-ikea-remotes']))))

--- a/src/remote.js
+++ b/src/remote.js
@@ -1,0 +1,38 @@
+"use strict";
+var Device   = require('./device.js');
+
+module.exports = class Remote extends Device {
+
+    constructor(platform, device) {
+        super(platform, device);
+
+        this.services.battery = new this.Service.BatteryService(`${this.name} Battery`);
+        this.lowBatteryLimit = platform.config.lowBatteryLimit || 10;
+        this.enableBattery();
+    }
+
+    deviceChanged(device) {
+        super.deviceChanged();
+        this.updateBatteryLevel();
+    }
+
+    enableBattery() {
+        var batteryLevel = this.services.battery.getCharacteristic(this.Characteristic.BatteryLevel);
+        batteryLevel.on('get', (callback) => {
+            callback(null, this.device.deviceInfo.battery);
+        });
+
+        var lowBatteryStatus = this.services.battery.getCharacteristic(this.Characteristic.StatusLowBattery);
+        lowBatteryStatus.on('get', (callback) => {
+            let battery = this.device.deviceInfo.battery
+            callback(null, battery <= this.lowBatteryLimit);
+        });
+    }
+
+    updateBatteryLevel() {
+        var lowBatteryStatus = this.blind.getCharacteristic(this.Characteristic.StatusLowBattery);
+        this.batteryLevel = this.device.deviceInfo.battery
+        this.log('Updating battery level to %s on blind \'%s\'', this.batteryLevel, this.name);
+        lowBatteryStatus.updateValue(this.batteryLevel <= this.lowBatteryLimit);
+    }
+};


### PR DESCRIPTION
The stock IKEA app doesn't show proper low-battery notifications and the homekit integration doesn't expose the remotes at all.
With this update, the remotes can be configured as BatteryService only, but thereby showing battery status in Home.
This helps in tracking why remotes might not work.